### PR TITLE
Fix for non-Multisite pages

### DIFF
--- a/fau-websso.php
+++ b/fau-websso.php
@@ -259,7 +259,9 @@ class FAU_WebSSO {
                 return $this->simplesaml_login_error(__('Zurzeit ist die Benutzer-Registrierung nicht erlaubt.', self::textdomain));
             }
 
-            switch_to_blog(1);
+						if (is_multisite()) {
+            	switch_to_blog(1);
+						}
             
             $account_data = array(
                 'user_pass' => wp_generate_password(12, false),


### PR DESCRIPTION
Die Funktion switch_to_blog() steht nur in Multisite Umgebungen von Wordpress bereit. Mit diesem Fix lässt sich das Plugin überall nutzen.